### PR TITLE
IllegalAccessException fix

### DIFF
--- a/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
+++ b/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
@@ -34,8 +34,12 @@ public class CompatiblePacketListener_v1_19_R1 implements CompatiblePacketListen
 
             final ClientboundPlayerChatPacket clientboundPlayerChatPacket = (ClientboundPlayerChatPacket) packet;
             final Optional<IChatBaseComponent> unsignedContent = clientboundPlayerChatPacket.d();
-            if (unsignedContent.isPresent())
+            if (unsignedContent.isPresent()) {
+                signedContentField.setAccessible(true);
                 signedContentField.set(clientboundPlayerChatPacket, unsignedContent.get());
+            }
+                
+            saltSignatureField.setAccessible(true);
             saltSignatureField.set(clientboundPlayerChatPacket, null);
 
         }


### PR DESCRIPTION
This commit fixes #2.

### Explanation:
Because of java.lang.IllegalAccessException - a thing which doesn't let you work with non-accessible fields, methods, etc,
you can't simply set the field without making it accessible, it will produce this exception.
That's why I added setAccessible().
