### PR TITLE
fix of #4 and one more fix of #2

### DIFF
--- a/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
+++ b/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
@@ -34,17 +34,12 @@ public class CompatiblePacketListener_v1_19_R1 implements CompatiblePacketListen
             final Optional<IChatBaseComponent> unsignedContent = clientboundPlayerChatPacket.d();
             if (unsignedContent.isPresent()) {
                 signedContentField.setAccessible(true);
-
-                // applying a fix of an issue called "can't set a field, which is final!" beforehand.
-                Field signedContentModifiers = Field.class.getDeclaredField("modifiers");
-                signedContentModifiers.setAccessible(true);
-                signedContentModifiers.setInt(signedContentModifiers, signedContentModifiers.getModifiers() & ~Modifier.FINAL);
-
                 signedContentField.set(clientboundPlayerChatPacket, unsignedContent.get());
             }
 
             saltSignatureField.setAccessible(true);
 
+            // applying a fix of an issue called "can't set a field, which is final!" beforehand.
             Field saltSignatureModifiers = Field.class.getDeclaredField("modifiers");
             saltSignatureModifiers.setAccessible(true);
             saltSignatureModifiers.setInt(saltSignatureModifiers, saltSignatureModifiers.getModifiers() & ~Modifier.FINAL);

--- a/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
+++ b/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
@@ -9,6 +9,7 @@ import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Optional;
 
 public class CompatiblePacketListener_v1_19_R1 implements CompatiblePacketListener {
@@ -29,16 +30,25 @@ public class CompatiblePacketListener_v1_19_R1 implements CompatiblePacketListen
 
     @Override
     public void writePacket(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise promise) throws Exception {
-
         if (packet instanceof final ClientboundPlayerChatPacket clientboundPlayerChatPacket) {
-
             final Optional<IChatBaseComponent> unsignedContent = clientboundPlayerChatPacket.d();
             if (unsignedContent.isPresent()) {
                 signedContentField.setAccessible(true);
+
+                // applying a fix of an issue called "can't set a field, which is final!" beforehand.
+                Field signedContentModifiers = Field.class.getDeclaredField("modifiers");
+                signedContentModifiers.setAccessible(true);
+                signedContentModifiers.setInt(signedContentModifiers, signedContentModifiers.getModifiers() & ~Modifier.FINAL);
+
                 signedContentField.set(clientboundPlayerChatPacket, unsignedContent.get());
             }
-                
+
             saltSignatureField.setAccessible(true);
+
+            Field saltSignatureModifiers = Field.class.getDeclaredField("modifiers");
+            saltSignatureModifiers.setAccessible(true);
+            saltSignatureModifiers.setInt(saltSignatureModifiers, saltSignatureModifiers.getModifiers() & ~Modifier.FINAL);
+
             saltSignatureField.set(clientboundPlayerChatPacket, null);
 
         }


### PR DESCRIPTION
### explanation

on the previous thing, i guess i missed one thing - some fields are private and u still need to set it
so i added a fix of this.

how does it work:
actually, 'field.getModifiers() & ~Modifier.FINAL' disables the bit, which is a final modifier in field.getModifiers().