### PR TITLE
1.19.1 Multi Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.19-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.19.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.19-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.19.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -72,8 +72,8 @@
                         <id>remap-spigot</id>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.19-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.19-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.19.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.19.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>
@@ -102,13 +102,13 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.19.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.19.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
             <classifier>remapped-mojang</classifier>
         </dependency>

--- a/src/main/java/me/doclic/noencryption/compatibility/Compatibility.java
+++ b/src/main/java/me/doclic/noencryption/compatibility/Compatibility.java
@@ -14,22 +14,31 @@ public class Compatibility {
     public static final boolean SERVER_COMPATIBLE;
     public static final String SERVER_VERSION;
 
+    public static final String COMPATIBLE_VERSION;
+    public static final String BUKKIT_VERSION;
+
     static {
 
+        COMPATIBLE_VERSION = "1.19.1-R0.1-SNAPSHOT";
+
         String minecraftVersion;
+        String bukkitVersion;
 
         try {
 
             minecraftVersion = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3]; // Gets the server version
+            bukkitVersion = Bukkit.getBukkitVersion(); // Gets the Bukkit version
 
 
         } catch (ArrayIndexOutOfBoundsException exception) {
             minecraftVersion = null;
+            bukkitVersion = null;
         }
 
         SERVER_VERSION = minecraftVersion;
+        BUKKIT_VERSION = bukkitVersion;
 
-        Bukkit.getLogger().info("Your server is running version " + minecraftVersion);
+        Bukkit.getLogger().info("Your server is running version " + bukkitVersion);
 
         if (minecraftVersion != null) {
 

--- a/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
+++ b/src/main/java/me/doclic/noencryption/compatibility/v1_19_R1/CompatiblePacketListener_v1_19_R1.java
@@ -3,11 +3,14 @@ package me.doclic.noencryption.compatibility.v1_19_R1;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import me.doclic.noencryption.compatibility.CompatiblePacketListener;
-import net.minecraft.network.chat.Component;
+import net.md_5.bungee.chat.ComponentSerializer;
+import net.minecraft.network.chat.*;
+import net.minecraft.network.protocol.game.ClientboundPlayerChatHeaderPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
-import net.minecraft.util.Crypt.SaltSignaturePair;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public class CompatiblePacketListener_v1_19_R1 implements CompatiblePacketListener {
 
@@ -17,17 +20,48 @@ public class CompatiblePacketListener_v1_19_R1 implements CompatiblePacketListen
     @Override
     public Object writePacket(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise promise) throws Exception {
         if (packet instanceof final ClientboundPlayerChatPacket clientboundPlayerChatPacket) {
-            final Optional<Component> unsignedContent = clientboundPlayerChatPacket.unsignedContent();
+            final Optional<Component> unsignedContent = clientboundPlayerChatPacket.message().unsignedContent();
+            final ChatMessageContent signedContent = clientboundPlayerChatPacket.message().signedContent();
+            final SignedMessageBody signedBody = clientboundPlayerChatPacket.message().signedBody();
+            final ChatType.BoundNetwork chatType = clientboundPlayerChatPacket.chatType();
 
             // recreate a new packet
             return new ClientboundPlayerChatPacket(
-                    unsignedContent.orElse(clientboundPlayerChatPacket.signedContent()), // use unsigned content if available, this is the signed content field
-                    unsignedContent, // unsigned content field
-                    clientboundPlayerChatPacket.typeId(),
-                    clientboundPlayerChatPacket.sender(),
-                    clientboundPlayerChatPacket.timeStamp(),
-                    new SaltSignaturePair(0, new byte[0])); // salt signature field
-            }
+                    new PlayerChatMessage(
+                            new SignedMessageHeader(
+                                    new MessageSignature(new byte[0]),
+                                    new UUID(0,0)),
+                            new MessageSignature(new byte[0]),
+                            new SignedMessageBody(
+                                    new ChatMessageContent(
+                                            signedContent.plain(),
+                                            signedContent.decorated()),
+                                    signedBody.timeStamp(),
+                                    0,
+                                    signedBody.lastSeen()),
+                            unsignedContent,
+                            new FilterMask(0)
+                    ),
+                    chatType);
+        }
+
+        if (packet instanceof final ClientboundSystemChatPacket clientboundSystemChatPacket) {
+            // recreate a new packet
+            return new ClientboundSystemChatPacket(
+                    ComponentSerializer.parse(clientboundSystemChatPacket.content()),
+                    clientboundSystemChatPacket.overlay());
+        }
+
+        if (packet instanceof final ClientboundPlayerChatHeaderPacket clientboundPlayerChatHeaderPacket) {
+            // recreate a new packet
+            return new ClientboundPlayerChatHeaderPacket(
+                    new SignedMessageHeader(
+                            new MessageSignature(new byte[0]),
+                            new UUID(0,0)),
+                    new MessageSignature(new byte[0]),
+                    clientboundPlayerChatHeaderPacket.bodyDigest()
+            );
+        }
 
         return packet;
 


### PR DESCRIPTION
Adds support for MC 1.19.1. 1.19 support is unavailable in this PR. I recommended to create a branch for 1.19 (current version, v2.0), duplicate of main, create a branch for 1.19.1, with this commit, then create a release with 1.19, and 1.19.1 jars. 

**The compiled version** (_slightly different code, but does the same thing. just my cleaned up version._) **can be found [here](https://github.com/V1nc3ntWasTaken/NoEncryption/releases/tag/3.1)**.