### PR TITLE
Add an option to forward message sender UUIDs

### DIFF
--- a/1.19.1/src/main/java/me/doclic/noencryption/compatibility/CompatiblePacketListener.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/compatibility/CompatiblePacketListener.java
@@ -2,6 +2,7 @@ package me.doclic.noencryption.compatibility;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import me.doclic.noencryption.config.ConfigurationHandler;
 import net.minecraft.network.chat.*;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatHeaderPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
@@ -28,7 +29,7 @@ public class CompatiblePacketListener {
                     new PlayerChatMessage(
                             new SignedMessageHeader(
                                     new MessageSignature(new byte[0]),
-                                    new UUID(0, 0)),
+                                    (ConfigurationHandler.getForwardUUID() ? clientboundPlayerChatPacket.message().signedHeader().sender() : new UUID(0, 0))),
                             new MessageSignature(new byte[0]),
                             new SignedMessageBody(
                                     new ChatMessageContent(

--- a/1.19.1/src/main/java/me/doclic/noencryption/config/ConfigNodes.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/config/ConfigNodes.java
@@ -47,7 +47,16 @@ public enum ConfigNodes {
             "# Note: Leave blank to disable",
             "# ",
             "# Added in v3.0",
-            "# Default: BLANK");
+            "# Default: BLANK"),
+
+    FORWARD_UUID(null, "forward_uuid", false,
+            " ",
+            "# Forwards UUIDs of message senders. This may improve functionality of some client-side mods/plugins",
+            "# ",
+            "# Note: Enabling this option may cause chat messages to not be fully stripped, thus showing the red bar, and red exclamation mark",
+            "# ",
+            "# Added in v3.1",
+            "# Default: false");
 
 
     private final String Notice;

--- a/1.19.1/src/main/java/me/doclic/noencryption/config/ConfigurationHandler.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/config/ConfigurationHandler.java
@@ -181,4 +181,8 @@ public class ConfigurationHandler {
     public static String getLoginProtectionMessage() {
         return getString(ConfigNodes.LOGIN_PROTECTION_MESSAGE);
     }
+
+    public static boolean getForwardUUID() {
+        return getBoolean(ConfigNodes.FORWARD_UUID);
+    }
 }

--- a/1.19.2/src/main/java/me/doclic/noencryption/compatibility/CompatiblePacketListener.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/compatibility/CompatiblePacketListener.java
@@ -2,6 +2,7 @@ package me.doclic.noencryption.compatibility;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import me.doclic.noencryption.config.ConfigurationHandler;
 import net.minecraft.network.chat.*;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatHeaderPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
@@ -28,7 +29,7 @@ public class CompatiblePacketListener {
                     new PlayerChatMessage(
                             new SignedMessageHeader(
                                     new MessageSignature(new byte[0]),
-                                    new UUID(0, 0)),
+                                    (ConfigurationHandler.getForwardUUID() ? clientboundPlayerChatPacket.message().signedHeader().sender() : new UUID(0, 0))),
                             new MessageSignature(new byte[0]),
                             new SignedMessageBody(
                                     new ChatMessageContent(

--- a/1.19.2/src/main/java/me/doclic/noencryption/config/ConfigNodes.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/config/ConfigNodes.java
@@ -47,7 +47,16 @@ public enum ConfigNodes {
             "# Note: Leave blank to disable",
             "# ",
             "# Added in v3.0",
-            "# Default: BLANK");
+            "# Default: BLANK"),
+
+    FORWARD_UUID(null, "forward_uuid", false,
+            " ",
+            "# Forwards UUIDs of message senders. This may improve functionality of some client-side mods/plugins",
+            "# ",
+            "# Note: Enabling this option may cause chat messages to not be fully stripped, thus showing the red bar, and red exclamation mark",
+            "# ",
+            "# Added in v3.1",
+            "# Default: false");
 
 
     private final String Notice;

--- a/1.19.2/src/main/java/me/doclic/noencryption/config/ConfigurationHandler.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/config/ConfigurationHandler.java
@@ -181,4 +181,8 @@ public class ConfigurationHandler {
     public static String getLoginProtectionMessage() {
         return getString(ConfigNodes.LOGIN_PROTECTION_MESSAGE);
     }
+
+    public static boolean getForwardUUID() {
+        return getBoolean(ConfigNodes.FORWARD_UUID);
+    }
 }


### PR DESCRIPTION
Added an option to forward message sender UUIDs. This allows client-side mods to work more smooth, as well as other client-side mods that use message UUIDs to find the sender of a message. Note, this does cause the red bar, and red exclamation point to re-appear.