### PR TITLE
Fix an error if packet_handler isn't found

### DIFF
--- a/1.19.1/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -17,7 +17,7 @@ public class PlayerListener implements Listener {
 
         final Player player = e.getPlayer();
         final ChannelPipeline pipeline = Compatibility.COMPATIBLE_PLAYER.getChannel(player).pipeline();
-        pipeline.addBefore("packet_handler", player.getUniqueId().toString(), new ChannelDuplexHandler() {
+        final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
 
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -35,7 +35,13 @@ public class PlayerListener implements Listener {
 
             }
 
-        });
+        };
+
+        if (pipeline.get("packet_handler") == null) {
+            pipeline.addLast(player.getUniqueId().toString(), handler);
+        } else {
+            pipeline.addBefore("packet_handler", player.getUniqueId().toString(), handler);
+        }
 
         if (ConfigurationHandler.getLoginProtectionMessage() != null) {
             if (!ConfigurationHandler.getLoginProtectionMessage().trim().equals("")) {

--- a/1.19.2/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -17,7 +17,7 @@ public class PlayerListener implements Listener {
 
         final Player player = e.getPlayer();
         final ChannelPipeline pipeline = Compatibility.COMPATIBLE_PLAYER.getChannel(player).pipeline();
-        pipeline.addBefore("packet_handler", player.getUniqueId().toString(), new ChannelDuplexHandler() {
+        final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
 
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -35,7 +35,13 @@ public class PlayerListener implements Listener {
 
             }
 
-        });
+        };
+
+        if (pipeline.get("packet_handler") == null) {
+            pipeline.addLast(player.getUniqueId().toString(), handler);
+        } else {
+            pipeline.addBefore("packet_handler", player.getUniqueId().toString(), handler);
+        }
 
         if (ConfigurationHandler.getLoginProtectionMessage() != null) {
             if (!ConfigurationHandler.getLoginProtectionMessage().trim().equals("")) {

--- a/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -17,7 +17,7 @@ public class PlayerListener implements Listener {
 
         final Player player = e.getPlayer();
         final ChannelPipeline pipeline = Compatibility.COMPATIBLE_PLAYER.getChannel(player).pipeline();
-        pipeline.addBefore("packet_handler", player.getUniqueId().toString(), new ChannelDuplexHandler() {
+        final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
 
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -35,7 +35,13 @@ public class PlayerListener implements Listener {
 
             }
 
-        });
+        };
+
+        if (pipeline.get("packet_handler") == null) {
+            pipeline.addLast(player.getUniqueId().toString(), handler);
+        } else {
+            pipeline.addBefore("packet_handler", player.getUniqueId().toString(), handler);
+        }
 
         if (ConfigurationHandler.getLoginProtectionMessage() != null) {
             if (!ConfigurationHandler.getLoginProtectionMessage().trim().equals("")) {

--- a/1.19/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -17,7 +17,7 @@ public class PlayerListener implements Listener {
 
         final Player player = e.getPlayer();
         final ChannelPipeline pipeline = Compatibility.COMPATIBLE_PLAYER.getChannel(player).pipeline();
-        pipeline.addBefore("packet_handler", player.getUniqueId().toString(), new ChannelDuplexHandler() {
+        final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
 
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -35,7 +35,13 @@ public class PlayerListener implements Listener {
 
             }
 
-        });
+        };
+
+        if (pipeline.get("packet_handler") == null) {
+            pipeline.addLast(player.getUniqueId().toString(), handler);
+        } else {
+            pipeline.addBefore("packet_handler", player.getUniqueId().toString(), handler);
+        }
 
         if (ConfigurationHandler.getLoginProtectionMessage() != null) {
             if (!ConfigurationHandler.getLoginProtectionMessage().trim().equals("")) {


### PR DESCRIPTION
Fixed an error if packet_handler isn't found in the connection pipeline when a player joins. This can occur for proxies