### PR TITLE
Fixed an improper shutdown when the plugin doesn't start properly

### DIFF
--- a/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -62,8 +62,11 @@ public class PlayerListener implements Listener {
     }
 
     public static void stopConnectionListenTimer() {
-        NoEncryption.timerTask.cancel();
-        NoEncryption.testerTask.cancel();
+        if (NoEncryption.timerTask != null)
+            NoEncryption.timerTask.cancel();
+
+        if (NoEncryption.testerTask != null)
+            NoEncryption.testerTask.cancel();
     }
 
     @EventHandler(priority = EventPriority.LOWEST)


### PR DESCRIPTION
Fixed an error when the plugin doesn't shut down properly for trying to cancel the connection timers before they are created