### PR TITLE
Java 17 update

### DIFF
--- a/1.19.1/pom.xml
+++ b/1.19.1/pom.xml
@@ -18,11 +18,6 @@
         <version>5.0</version>
     </parent>
 
-    <properties>
-        <java.version>1.17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -30,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/1.19.1/src/main/java/me/doclic/noencryption/commands/MainCommand.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/commands/MainCommand.java
@@ -33,31 +33,26 @@ public class MainCommand implements CommandExecutor, TabCompleter {
 
         try {
             switch (args[0].toLowerCase()) {
-                case "suppressnotices":
+                case "suppressnotices" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     if (!(sender instanceof ConsoleCommandSender)) {
                         Chat.sendChat(sender, "&c[NoEncryption] You can not run this command as a player!");
                         return true;
                     }
-
                     if (ConfigurationHandler.Notices.suppressNotices())
                         Chat.sendChat(sender, "&c[NoEncryption] &7Start up config messages suppressed");
                     else
                         Chat.sendChat(sender, "&c[NoEncryption] There are no active config messages to suppress");
-
-                    break;
-                case "checkforupdates":
+                }
+                case "checkforupdates" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     Chat.sendChat(sender, "&c[NoEncryption] &7Checking for updates...");
-
                     UpdateChecker.check(
                             () -> {
                                 Chat.sendChat(sender, "&c[NoEncryption] &7There is a new update available. You can download it here:");
@@ -73,10 +68,9 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                                 Chat.sendChat(sender, "https://www.githubstatus.com/");
                             }
                     );
-
-                    break;
-                default:
-                    Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
+                }
+                default ->
+                        Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             // Makes it easier to iterate through, and less code

--- a/1.19.1/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
@@ -36,12 +36,8 @@ public class UpdateChecker {
 
                 Bukkit.getScheduler().runTask(NoEncryption.plugin(), () -> {
                     switch (compare) {
-                        case -1:
-                            callbackIfOld.run();
-                            break;
-                        default:
-                            callbackIfSameOrNew.run();
-                            break;
+                        case -1 -> callbackIfOld.run();
+                        default -> callbackIfSameOrNew.run();
                     }
                 });
             } catch (IOException | ParseException e) {

--- a/1.19.2/pom.xml
+++ b/1.19.2/pom.xml
@@ -18,11 +18,6 @@
         <version>5.0</version>
     </parent>
 
-    <properties>
-        <java.version>1.17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -30,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/1.19.2/src/main/java/me/doclic/noencryption/commands/MainCommand.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/commands/MainCommand.java
@@ -33,31 +33,26 @@ public class MainCommand implements CommandExecutor, TabCompleter {
 
         try {
             switch (args[0].toLowerCase()) {
-                case "suppressnotices":
+                case "suppressnotices" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     if (!(sender instanceof ConsoleCommandSender)) {
                         Chat.sendChat(sender, "&c[NoEncryption] You can not run this command as a player!");
                         return true;
                     }
-
                     if (ConfigurationHandler.Notices.suppressNotices())
                         Chat.sendChat(sender, "&c[NoEncryption] &7Start up config messages suppressed");
                     else
                         Chat.sendChat(sender, "&c[NoEncryption] There are no active config messages to suppress");
-
-                    break;
-                case "checkforupdates":
+                }
+                case "checkforupdates" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     Chat.sendChat(sender, "&c[NoEncryption] &7Checking for updates...");
-
                     UpdateChecker.check(
                             () -> {
                                 Chat.sendChat(sender, "&c[NoEncryption] &7There is a new update available. You can download it here:");
@@ -73,10 +68,9 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                                 Chat.sendChat(sender, "https://www.githubstatus.com/");
                             }
                     );
-
-                    break;
-                default:
-                    Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
+                }
+                default ->
+                        Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             // Makes it easier to iterate through, and less code

--- a/1.19.2/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
@@ -36,12 +36,8 @@ public class UpdateChecker {
 
                 Bukkit.getScheduler().runTask(NoEncryption.plugin(), () -> {
                     switch (compare) {
-                        case -1:
-                            callbackIfOld.run();
-                            break;
-                        default:
-                            callbackIfSameOrNew.run();
-                            break;
+                        case -1 -> callbackIfOld.run();
+                        default -> callbackIfSameOrNew.run();
                     }
                 });
             } catch (IOException | ParseException e) {

--- a/1.19.3/pom.xml
+++ b/1.19.3/pom.xml
@@ -18,11 +18,6 @@
         <version>5.0</version>
     </parent>
 
-    <properties>
-        <java.version>1.17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -30,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/1.19.3/src/main/java/me/doclic/noencryption/commands/MainCommand.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/commands/MainCommand.java
@@ -33,31 +33,26 @@ public class MainCommand implements CommandExecutor, TabCompleter {
 
         try {
             switch (args[0].toLowerCase()) {
-                case "suppressnotices":
+                case "suppressnotices" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     if (!(sender instanceof ConsoleCommandSender)) {
                         Chat.sendChat(sender, "&c[NoEncryption] You can not run this command as a player!");
                         return true;
                     }
-
                     if (ConfigurationHandler.Notices.suppressNotices())
                         Chat.sendChat(sender, "&c[NoEncryption] &7Start up config messages suppressed");
                     else
                         Chat.sendChat(sender, "&c[NoEncryption] There are no active config messages to suppress");
-
-                    break;
-                case "checkforupdates":
+                }
+                case "checkforupdates" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     Chat.sendChat(sender, "&c[NoEncryption] &7Checking for updates...");
-
                     UpdateChecker.check(
                             () -> {
                                 Chat.sendChat(sender, "&c[NoEncryption] &7There is a new update available. You can download it here:");
@@ -73,10 +68,9 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                                 Chat.sendChat(sender, "https://www.githubstatus.com/");
                             }
                     );
-
-                    break;
-                default:
-                    Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
+                }
+                default ->
+                        Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             // Makes it easier to iterate through, and less code

--- a/1.19.3/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
@@ -36,12 +36,8 @@ public class UpdateChecker {
 
                 Bukkit.getScheduler().runTask(NoEncryption.plugin(), () -> {
                     switch (compare) {
-                        case -1:
-                            callbackIfOld.run();
-                            break;
-                        default:
-                            callbackIfSameOrNew.run();
-                            break;
+                        case -1 -> callbackIfOld.run();
+                        default -> callbackIfSameOrNew.run();
                     }
                 });
             } catch (IOException | ParseException e) {

--- a/1.19.4/pom.xml
+++ b/1.19.4/pom.xml
@@ -18,11 +18,6 @@
         <version>5.0</version>
     </parent>
 
-    <properties>
-        <java.version>1.17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -30,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/1.19.4/src/main/java/me/doclic/noencryption/commands/MainCommand.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/commands/MainCommand.java
@@ -33,31 +33,26 @@ public class MainCommand implements CommandExecutor, TabCompleter {
 
         try {
             switch (args[0].toLowerCase()) {
-                case "suppressnotices":
+                case "suppressnotices" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     if (!(sender instanceof ConsoleCommandSender)) {
                         Chat.sendChat(sender, "&c[NoEncryption] You can not run this command as a player!");
                         return true;
                     }
-
                     if (ConfigurationHandler.Notices.suppressNotices())
                         Chat.sendChat(sender, "&c[NoEncryption] &7Start up config messages suppressed");
                     else
                         Chat.sendChat(sender, "&c[NoEncryption] There are no active config messages to suppress");
-
-                    break;
-                case "checkforupdates":
+                }
+                case "checkforupdates" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     Chat.sendChat(sender, "&c[NoEncryption] &7Checking for updates...");
-
                     UpdateChecker.check(
                             () -> {
                                 Chat.sendChat(sender, "&c[NoEncryption] &7There is a new update available. You can download it here:");
@@ -73,10 +68,9 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                                 Chat.sendChat(sender, "https://www.githubstatus.com/");
                             }
                     );
-
-                    break;
-                default:
-                    Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
+                }
+                default ->
+                        Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             // Makes it easier to iterate through, and less code

--- a/1.19.4/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
@@ -36,12 +36,8 @@ public class UpdateChecker {
 
                 Bukkit.getScheduler().runTask(NoEncryption.plugin(), () -> {
                     switch (compare) {
-                        case -1:
-                            callbackIfOld.run();
-                            break;
-                        default:
-                            callbackIfSameOrNew.run();
-                            break;
+                        case -1 -> callbackIfOld.run();
+                        default -> callbackIfSameOrNew.run();
                     }
                 });
             } catch (IOException | ParseException e) {

--- a/1.19/pom.xml
+++ b/1.19/pom.xml
@@ -18,11 +18,6 @@
         <version>5.0</version>
     </parent>
 
-    <properties>
-        <java.version>1.17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -30,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/1.19/src/main/java/me/doclic/noencryption/commands/MainCommand.java
+++ b/1.19/src/main/java/me/doclic/noencryption/commands/MainCommand.java
@@ -33,31 +33,26 @@ public class MainCommand implements CommandExecutor, TabCompleter {
 
         try {
             switch (args[0].toLowerCase()) {
-                case "suppressnotices":
+                case "suppressnotices" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     if (!(sender instanceof ConsoleCommandSender)) {
                         Chat.sendChat(sender, "&c[NoEncryption] You can not run this command as a player!");
                         return true;
                     }
-
                     if (ConfigurationHandler.Notices.suppressNotices())
                         Chat.sendChat(sender, "&c[NoEncryption] &7Start up config messages suppressed");
                     else
                         Chat.sendChat(sender, "&c[NoEncryption] There are no active config messages to suppress");
-
-                    break;
-                case "checkforupdates":
+                }
+                case "checkforupdates" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     Chat.sendChat(sender, "&c[NoEncryption] &7Checking for updates...");
-
                     UpdateChecker.check(
                             () -> {
                                 Chat.sendChat(sender, "&c[NoEncryption] &7There is a new update available. You can download it here:");
@@ -73,10 +68,9 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                                 Chat.sendChat(sender, "https://www.githubstatus.com/");
                             }
                     );
-
-                    break;
-                default:
-                    Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
+                }
+                default ->
+                        Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             // Makes it easier to iterate through, and less code

--- a/1.19/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
+++ b/1.19/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
@@ -36,12 +36,8 @@ public class UpdateChecker {
 
                 Bukkit.getScheduler().runTask(NoEncryption.plugin(), () -> {
                     switch (compare) {
-                        case -1:
-                            callbackIfOld.run();
-                            break;
-                        default:
-                            callbackIfSameOrNew.run();
-                            break;
+                        case -1 -> callbackIfOld.run();
+                        default -> callbackIfSameOrNew.run();
                     }
                 });
             } catch (IOException | ParseException e) {

--- a/Reflection/pom.xml
+++ b/Reflection/pom.xml
@@ -18,11 +18,6 @@
         <version>5.0</version>
     </parent>
 
-    <properties>
-        <java.version>1.17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -30,8 +25,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/Reflection/src/main/java/me/doclic/noencryption/commands/MainCommand.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/commands/MainCommand.java
@@ -33,31 +33,26 @@ public class MainCommand implements CommandExecutor, TabCompleter {
 
         try {
             switch (args[0].toLowerCase()) {
-                case "suppressnotices":
+                case "suppressnotices" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     if (!(sender instanceof ConsoleCommandSender)) {
                         Chat.sendChat(sender, "&c[NoEncryption] You can not run this command as a player!");
                         return true;
                     }
-
                     if (ConfigurationHandler.Notices.suppressNotices())
                         Chat.sendChat(sender, "&c[NoEncryption] &7Start up config messages suppressed");
                     else
                         Chat.sendChat(sender, "&c[NoEncryption] There are no active config messages to suppress");
-
-                    break;
-                case "checkforupdates":
+                }
+                case "checkforupdates" -> {
                     if (!sender.hasPermission("noencryption.command.suppressnotices")) {
                         Chat.sendChat(sender, "&c[NoEncryption] You do not have permission to run this command!");
                         return true;
                     }
-
                     Chat.sendChat(sender, "&c[NoEncryption] &7Checking for updates...");
-
                     UpdateChecker.check(
                             () -> {
                                 Chat.sendChat(sender, "&c[NoEncryption] &7There is a new update available. You can download it here:");
@@ -73,10 +68,9 @@ public class MainCommand implements CommandExecutor, TabCompleter {
                                 Chat.sendChat(sender, "https://www.githubstatus.com/");
                             }
                     );
-
-                    break;
-                default:
-                    Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
+                }
+                default ->
+                        Chat.sendChat(sender, "&c[NoEncryption] Invalid argument \"" + ChatColor.stripColor(args[0]) + "\"!");
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             // Makes it easier to iterate through, and less code

--- a/Reflection/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/utils/updates/UpdateChecker.java
@@ -36,12 +36,8 @@ public class UpdateChecker {
 
                 Bukkit.getScheduler().runTask(NoEncryption.plugin(), () -> {
                     switch (compare) {
-                        case -1:
-                            callbackIfOld.run();
-                            break;
-                        default:
-                            callbackIfSameOrNew.run();
-                            break;
+                        case -1 -> callbackIfOld.run();
+                        default -> callbackIfSameOrNew.run();
                     }
                 });
             } catch (IOException | ParseException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <java.version>1.17</java.version>
+        <java.level>17</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -33,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.level}</source>
+                    <target>${java.level}</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
<details>
<summary>By creating a pull request, you agree to the following</summary>

<ul>
<li>The code included in this PR is in no way malicious, or used for my personal gain.</li>
<li>The code included in this PR is intended to benefit, add a universal feature, fix a bug(s), or make a function more efficient.</li>
<li>The code included in this PR is <b>not</b> intended for one time use/personal use. (ex. compatibility with your personal plugin)</li>
<li>The code included in this PR follows the licensing of it's origination.</li>
<li>The code included in this PR is tested, and follows all laws, regulations, rules, and other listed restrictions.</li>
</ul>

</details>

## Type of Change

What type of fix(es) are included in this pull request?

- [ ] Bug Fix
- [ ] New Feature
- [X] Other (Describe below)

<details>
  <summary><h3>Other (Only applies if Other is selected above)</h3></summary>
  <br>
  
  - Update the compile Java version to Java 17
  
</details>

## Link(s) to related issue(s) and their issue number(s)

List of links to issues that this PR relates to or closes

- Java compilation target is under the requirement for Minecraft 1.19 [#75](https://github.com/Doclic/NoEncryption/issues/75)

## Changes

Describe all the changes that were made

- Changed child POMs to rely on the parent POM's properties
- Changed POMs to source and target Java 17
- Changed `MainCommands.java` and `UpdateChecker.java` to use enhanced `switch` statements

## Testing Required

Do the applied changes require testing? (Depends on if core components were changed)

- [X] Yes, these changes require testing
- [ ] No, these changes do not require testing

<details>
  <summary><b>Testing Environment (If the above is Yes)</b></summary>
  <br>
  
  <b>1.19 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19 Build 1735
  - [X] Tested player joining
  - [X] Tested chats **Player -> Server**
  - [X] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [X] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [X] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.1 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19.1 Build 1751
  - [X] Tested player joining
  - [X] Tested chats **Player -> Server**
  - [X] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [X] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [X] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.2 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19.2 Build 1858
  - [X] Tested player joining
  - [X] Tested chats **Player -> Server**
  - [X] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [X] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [X] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.3 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19.3 Build 1920
  - [X] Tested player joining
  - [X] Tested chats **Player -> Server**
  - [X] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [X] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [X] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.4 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Paper 1.19.4 Build 451
  - [X] Tested player joining
  - [X] Tested chats **Player -> Server**
  - [X] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [X] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [X] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [X] Tested Reflection with above
  
</details>

## Self Review

- [X] I have performed a self-review of my code
- [X] My code successfully compiles through Maven every time, without any compiler warnings
- [X] My code has been checked for leftover development code/comments such as debug outputs
