### PR TITLE
Added a null check for player channels

### DIFF
--- a/1.19.1/src/main/java/me/doclic/noencryption/NoEncryption.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/NoEncryption.java
@@ -1,24 +1,36 @@
 package me.doclic.noencryption;
 
+import io.netty.channel.Channel;
 import me.doclic.noencryption.commands.MainCommand;
 import me.doclic.noencryption.compatibility.Compatibility;
 import me.doclic.noencryption.config.ConfigurationHandler;
+import me.doclic.noencryption.utils.PlayerChannelGC;
 import me.doclic.noencryption.utils.FileMgmt;
 import me.doclic.noencryption.utils.InternalMetrics;
 import me.doclic.noencryption.utils.updates.UpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Logger;
 
 public final class NoEncryption extends JavaPlugin {
     private static NoEncryption plugin;
     private static Logger logger;
+    public static List<Channel> activePlayerChannels;
+
+    private static BukkitTask playerGarbageCollectorTask;
+
+    public static final String playerHandlerName = "noencryption_playerlevel";
 
     @Override
     public void onEnable() {
         plugin = this;
         logger = getLogger();
+        activePlayerChannels = Collections.unmodifiableList(new ArrayList<>());
 
         if (Compatibility.SERVER_COMPATIBLE) {
             FileMgmt.initialize(this);
@@ -36,25 +48,27 @@ public final class NoEncryption extends JavaPlugin {
             getCommand("noencryption").setExecutor(new MainCommand());
             getCommand("noencryption").setTabCompleter(new MainCommand());
 
+            startTasks();
+
             Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
 
             if (ConfigurationHandler.Config.doAutoUpdateCheck())
                 UpdateChecker.check(
-                        () -> {
-                            logger().info("You are running an old version of NoEncryption.");
-                            logger().info("It is recommended to update to the latest version");
-                            logger().info("for the best experience. The update can be found here:");
-                            logger().info(UpdateChecker.updateUrl.toString());
-                        },
-                        () -> {
-                            logger().info("Your NoEncryption version is up-to-date");
-                        },
-                        () -> {
-                            logger().info("Could not check for the latest version of NoEncryption.");
-                            logger().info("It is recommended to update to the latest version");
-                            logger().info("for the best experience. The update can be found here:");
-                            logger().info(UpdateChecker.updateUrl.toString());
-                        }
+                    () -> {
+                        logger().info("You are running an old version of NoEncryption.");
+                        logger().info("It is recommended to update to the latest version");
+                        logger().info("for the best experience. The update can be found here:");
+                        logger().info(UpdateChecker.updateUrl.toString());
+                    },
+                    () -> {
+                        logger().info("Your NoEncryption version is up-to-date");
+                    },
+                    () -> {
+                        logger().info("Could not check for the latest version of NoEncryption.");
+                        logger().info("It is recommended to update to the latest version");
+                        logger().info("for the best experience. The update can be found here:");
+                        logger().info(UpdateChecker.updateUrl.toString());
+                    }
                 );
 
             logger().info("Compatibility successful!");
@@ -86,6 +100,19 @@ public final class NoEncryption extends JavaPlugin {
 
     }
 
+    @Override
+    public void onDisable() {
+        stopTasks();
+    }
+
+    private static void startTasks() {
+        playerGarbageCollectorTask = PlayerChannelGC.start();
+    }
+
+    private static void stopTasks() {
+        PlayerChannelGC.stop(playerGarbageCollectorTask);
+    }
+
     public static NoEncryption plugin() {
         return plugin;
     }
@@ -106,5 +133,17 @@ public final class NoEncryption extends JavaPlugin {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    public static void addPlayerChannel(Channel channel) {
+        List<Channel> modified = new ArrayList<>(activePlayerChannels);
+        modified.add(channel);
+        activePlayerChannels = Collections.unmodifiableList(modified);
+    }
+
+    public static void removePlayerChannel(Channel channel) {
+        List<Channel> modified = new ArrayList<>(activePlayerChannels);
+        modified.remove(channel);
+        activePlayerChannels = Collections.unmodifiableList(modified);
     }
 }

--- a/1.19.1/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -46,6 +46,12 @@ public class PlayerListener implements Listener {
     public void onPlayerQuit (PlayerQuitEvent e) {
         final Player player = e.getPlayer();
         final Channel channel = Compatibility.COMPATIBLE_PLAYER.getChannel(player);
-        channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+
+        try {
+            channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+        } catch (NullPointerException ex) {
+            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            ex.printStackTrace();
+        }
     }
 }

--- a/1.19.1/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
@@ -1,0 +1,30 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class PlayerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), PlayerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.activePlayerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.playerHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.playerHandlerName);
+
+                    NoEncryption.removePlayerChannel(channel);
+                } else {
+                    NoEncryption.removePlayerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/1.19.2/src/main/java/me/doclic/noencryption/NoEncryption.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/NoEncryption.java
@@ -1,24 +1,36 @@
 package me.doclic.noencryption;
 
+import io.netty.channel.Channel;
 import me.doclic.noencryption.commands.MainCommand;
 import me.doclic.noencryption.compatibility.Compatibility;
 import me.doclic.noencryption.config.ConfigurationHandler;
+import me.doclic.noencryption.utils.PlayerChannelGC;
 import me.doclic.noencryption.utils.FileMgmt;
 import me.doclic.noencryption.utils.InternalMetrics;
 import me.doclic.noencryption.utils.updates.UpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Logger;
 
 public final class NoEncryption extends JavaPlugin {
     private static NoEncryption plugin;
     private static Logger logger;
+    public static List<Channel> activePlayerChannels;
+
+    private static BukkitTask playerGarbageCollectorTask;
+
+    public static final String playerHandlerName = "noencryption_playerlevel";
 
     @Override
     public void onEnable() {
         plugin = this;
         logger = getLogger();
+        activePlayerChannels = Collections.unmodifiableList(new ArrayList<>());
 
         if (Compatibility.SERVER_COMPATIBLE) {
             FileMgmt.initialize(this);
@@ -36,25 +48,27 @@ public final class NoEncryption extends JavaPlugin {
             getCommand("noencryption").setExecutor(new MainCommand());
             getCommand("noencryption").setTabCompleter(new MainCommand());
 
+            startTasks();
+
             Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
 
             if (ConfigurationHandler.Config.doAutoUpdateCheck())
                 UpdateChecker.check(
-                        () -> {
-                            logger().info("You are running an old version of NoEncryption.");
-                            logger().info("It is recommended to update to the latest version");
-                            logger().info("for the best experience. The update can be found here:");
-                            logger().info(UpdateChecker.updateUrl.toString());
-                        },
-                        () -> {
-                            logger().info("Your NoEncryption version is up-to-date");
-                        },
-                        () -> {
-                            logger().info("Could not check for the latest version of NoEncryption.");
-                            logger().info("It is recommended to update to the latest version");
-                            logger().info("for the best experience. The update can be found here:");
-                            logger().info(UpdateChecker.updateUrl.toString());
-                        }
+                    () -> {
+                        logger().info("You are running an old version of NoEncryption.");
+                        logger().info("It is recommended to update to the latest version");
+                        logger().info("for the best experience. The update can be found here:");
+                        logger().info(UpdateChecker.updateUrl.toString());
+                    },
+                    () -> {
+                        logger().info("Your NoEncryption version is up-to-date");
+                    },
+                    () -> {
+                        logger().info("Could not check for the latest version of NoEncryption.");
+                        logger().info("It is recommended to update to the latest version");
+                        logger().info("for the best experience. The update can be found here:");
+                        logger().info(UpdateChecker.updateUrl.toString());
+                    }
                 );
 
             logger().info("Compatibility successful!");
@@ -86,6 +100,19 @@ public final class NoEncryption extends JavaPlugin {
 
     }
 
+    @Override
+    public void onDisable() {
+        stopTasks();
+    }
+
+    private static void startTasks() {
+        playerGarbageCollectorTask = PlayerChannelGC.start();
+    }
+
+    private static void stopTasks() {
+        PlayerChannelGC.stop(playerGarbageCollectorTask);
+    }
+
     public static NoEncryption plugin() {
         return plugin;
     }
@@ -106,5 +133,17 @@ public final class NoEncryption extends JavaPlugin {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    public static void addPlayerChannel(Channel channel) {
+        List<Channel> modified = new ArrayList<>(activePlayerChannels);
+        modified.add(channel);
+        activePlayerChannels = Collections.unmodifiableList(modified);
+    }
+
+    public static void removePlayerChannel(Channel channel) {
+        List<Channel> modified = new ArrayList<>(activePlayerChannels);
+        modified.remove(channel);
+        activePlayerChannels = Collections.unmodifiableList(modified);
     }
 }

--- a/1.19.2/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -46,6 +46,12 @@ public class PlayerListener implements Listener {
     public void onPlayerQuit (PlayerQuitEvent e) {
         final Player player = e.getPlayer();
         final Channel channel = Compatibility.COMPATIBLE_PLAYER.getChannel(player);
-        channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+
+        try {
+            channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+        } catch (NullPointerException ex) {
+            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            ex.printStackTrace();
+        }
     }
 }

--- a/1.19.2/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
@@ -1,0 +1,30 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class PlayerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), PlayerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.activePlayerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.playerHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.playerHandlerName);
+
+                    NoEncryption.removePlayerChannel(channel);
+                } else {
+                    NoEncryption.removePlayerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/1.19.3/src/main/java/me/doclic/noencryption/ConnectionListener.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/ConnectionListener.java
@@ -1,0 +1,57 @@
+package me.doclic.noencryption;
+
+import io.netty.channel.*;
+import me.doclic.noencryption.compatibility.Compatibility;
+import net.minecraft.network.protocol.login.ClientboundGameProfilePacket;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class ConnectionListener {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), ConnectionListener::runCatch, 1, 1);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runCatch() {
+        Compatibility.COMPATIBLE_PLAYER.getServerConnections().forEach(connection -> {
+            Channel channel = connection.channel;
+            ChannelPipeline pipeline = channel.pipeline();
+
+            if (pipeline.get(NoEncryption.serverHandlerName) == null) {
+                final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
+                        Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.readPacket(channelHandlerContext, packet);
+                        super.channelRead(channelHandlerContext, newPacket);
+                    }
+
+                    @Override
+                    public void write(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise promise) throws Exception {
+                        this.handleConnectionChannel(packet);
+
+                        Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.writePacket(channelHandlerContext, packet, promise, false);
+                        super.write(channelHandlerContext, newPacket, promise);
+                    }
+
+                    public void handleConnectionChannel(Object packet) {
+                        if (packet instanceof ClientboundGameProfilePacket clientboundGameProfilePacket) {
+                            NoEncryption.serverChannels.put(clientboundGameProfilePacket.getGameProfile().getId(), channel);
+                        }
+                    }
+                };
+
+                if (pipeline.get("packet_handler") == null) {
+                    pipeline.addLast(NoEncryption.serverHandlerName, handler);
+                } else {
+                    pipeline.addBefore("packet_handler", NoEncryption.serverHandlerName, handler);
+                }
+
+                NoEncryption.addServerChannel(channel);
+            }
+        });
+    }
+}

--- a/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -3,8 +3,6 @@ package me.doclic.noencryption;
 import io.netty.channel.*;
 import me.doclic.noencryption.compatibility.Compatibility;
 import me.doclic.noencryption.config.ConfigurationHandler;
-import net.minecraft.network.protocol.login.ClientboundGameProfilePacket;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -13,66 +11,11 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {
-    public static void startConnectionListenTimer() {
-        NoEncryption.timerTask = Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), () -> {
-            Compatibility.COMPATIBLE_PLAYER.getServerConnections().forEach(connection -> {
-                Channel channel = connection.channel;
-                ChannelPipeline pipeline = channel.pipeline();
-
-                if (pipeline.get("noencryption_serverlevel") == null) {
-                    final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
-                        @Override
-                        public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
-                            Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.readPacket(channelHandlerContext, packet);
-                            super.channelRead(channelHandlerContext, newPacket);
-                        }
-
-                        @Override
-                        public void write(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise promise) throws Exception {
-                            this.handleConnectionChannel(packet);
-
-                            Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.writePacket(channelHandlerContext, packet, promise, false);
-                            super.write(channelHandlerContext, newPacket, promise);
-                        }
-
-                        public void handleConnectionChannel(Object packet) {
-                            if (packet instanceof ClientboundGameProfilePacket clientboundGameProfilePacket) {
-                                NoEncryption.serverChannels.put(clientboundGameProfilePacket.getGameProfile().getId(), channel);
-                            }
-                        }
-                    };
-
-                    if (pipeline.get("packet_handler") == null) {
-                        pipeline.addLast("noencryption_serverlevel", handler);
-                    } else {
-                        pipeline.addBefore("packet_handler", "noencryption_serverlevel", handler);
-                    }
-                }
-            });
-        }, 1, 1);
-
-        NoEncryption.testerTask = Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), () -> {
-            NoEncryption.serverChannels.forEach((uuid, channel) -> {
-                if (Bukkit.getPlayer(uuid) == null) {
-                    channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_serverlevel"));
-                    NoEncryption.serverChannels.remove(uuid);
-                }
-            });
-        }, 20, 20);
-    }
-
-    public static void stopConnectionListenTimer() {
-        if (NoEncryption.timerTask != null)
-            NoEncryption.timerTask.cancel();
-
-        if (NoEncryption.testerTask != null)
-            NoEncryption.testerTask.cancel();
-    }
-
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerJoin (PlayerJoinEvent e) {
         final Player player = e.getPlayer();
-        final ChannelPipeline pipeline = Compatibility.COMPATIBLE_PLAYER.getChannel(player).pipeline();
+        final Channel channel = Compatibility.COMPATIBLE_PLAYER.getChannel(player);
+        final ChannelPipeline pipeline = channel.pipeline();
         final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -88,9 +31,9 @@ public class PlayerListener implements Listener {
         };
 
         if (pipeline.get("packet_handler") == null) {
-            pipeline.addLast("noencryption_playerlevel", handler);
+            pipeline.addLast(NoEncryption.playerHandlerName, handler);
         } else {
-            pipeline.addBefore("packet_handler", "noencryption_playerlevel", handler);
+            pipeline.addBefore("packet_handler", NoEncryption.playerHandlerName, handler);
         }
 
         if (ConfigurationHandler.Config.getLoginProtectionMessage() != null) {
@@ -98,6 +41,8 @@ public class PlayerListener implements Listener {
                 Chat.sendChat(player, ConfigurationHandler.Config.getLoginProtectionMessage());
             }
         }
+
+        NoEncryption.addPlayerChannel(channel);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -107,7 +52,7 @@ public class PlayerListener implements Listener {
         final Channel serverChannel = NoEncryption.serverChannels.get(player.getUniqueId());
 
         try {
-            channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+            channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
 
             serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove("noencryption_serverlevel"));
             NoEncryption.serverChannels.remove(player.getUniqueId());

--- a/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -104,10 +104,16 @@ public class PlayerListener implements Listener {
     public void onPlayerQuit (PlayerQuitEvent e) {
         final Player player = e.getPlayer();
         final Channel channel = Compatibility.COMPATIBLE_PLAYER.getChannel(player);
-        channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+        final Channel serverChannel = NoEncryption.serverChannels.get(player.getUniqueId());
 
-        Channel serverChannel = NoEncryption.serverChannels.get(player.getUniqueId());
-        serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove("noencryption_serverlevel"));
-        NoEncryption.serverChannels.remove(player.getUniqueId());
+        try {
+            channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+
+            serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove("noencryption_serverlevel"));
+            NoEncryption.serverChannels.remove(player.getUniqueId());
+        } catch (NullPointerException ex) {
+            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            ex.printStackTrace();
+        }
     }
 }

--- a/1.19.3/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
@@ -1,0 +1,30 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class PlayerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), PlayerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.activePlayerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.playerHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.playerHandlerName);
+
+                    NoEncryption.removePlayerChannel(channel);
+                } else {
+                    NoEncryption.removePlayerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/1.19.3/src/main/java/me/doclic/noencryption/utils/ServerChannelGC.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/utils/ServerChannelGC.java
@@ -1,0 +1,37 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class ServerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), ServerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.serverChannels.forEach((uuid, channel) -> {
+            if (Bukkit.getPlayer(uuid) == null) {
+                channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.serverHandlerName));
+                NoEncryption.serverChannels.remove(uuid);
+            }
+        });
+
+        NoEncryption.activeServerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.serverHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.serverHandlerName);
+
+                    NoEncryption.removeServerChannel(channel);
+                } else {
+                    NoEncryption.removeServerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/1.19.4/src/main/java/me/doclic/noencryption/ConnectionListener.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/ConnectionListener.java
@@ -1,0 +1,57 @@
+package me.doclic.noencryption;
+
+import io.netty.channel.*;
+import me.doclic.noencryption.compatibility.Compatibility;
+import net.minecraft.network.protocol.login.ClientboundGameProfilePacket;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class ConnectionListener {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), ConnectionListener::runCatch, 1, 1);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runCatch() {
+        Compatibility.COMPATIBLE_PLAYER.getServerConnections().forEach(connection -> {
+            Channel channel = connection.channel;
+            ChannelPipeline pipeline = channel.pipeline();
+
+            if (pipeline.get(NoEncryption.serverHandlerName) == null) {
+                final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
+                        Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.readPacket(channelHandlerContext, packet);
+                        super.channelRead(channelHandlerContext, newPacket);
+                    }
+
+                    @Override
+                    public void write(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise promise) throws Exception {
+                        this.handleConnectionChannel(packet);
+
+                        Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.writePacket(channelHandlerContext, packet, promise, false);
+                        super.write(channelHandlerContext, newPacket, promise);
+                    }
+
+                    public void handleConnectionChannel(Object packet) {
+                        if (packet instanceof ClientboundGameProfilePacket clientboundGameProfilePacket) {
+                            NoEncryption.serverChannels.put(clientboundGameProfilePacket.getGameProfile().getId(), channel);
+                        }
+                    }
+                };
+
+                if (pipeline.get("packet_handler") == null) {
+                    pipeline.addLast(NoEncryption.serverHandlerName, handler);
+                } else {
+                    pipeline.addBefore("packet_handler", NoEncryption.serverHandlerName, handler);
+                }
+
+                NoEncryption.addServerChannel(channel);
+            }
+        });
+    }
+}

--- a/1.19.4/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -3,8 +3,6 @@ package me.doclic.noencryption;
 import io.netty.channel.*;
 import me.doclic.noencryption.compatibility.Compatibility;
 import me.doclic.noencryption.config.ConfigurationHandler;
-import net.minecraft.network.protocol.login.ClientboundGameProfilePacket;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -13,72 +11,17 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {
-    public static void startConnectionListenTimer() {
-        NoEncryption.timerTask = Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), () -> {
-            Compatibility.COMPATIBLE_PLAYER.getServerConnections().forEach(connection -> {
-                Channel channel = connection.channel;
-                ChannelPipeline pipeline = channel.pipeline();
-
-                if (pipeline.get("noencryption_serverlevel") == null) {
-                    final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
-                        @Override
-                        public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
-                            Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.readPacket(channelHandlerContext, packet);
-                            super.channelRead(channelHandlerContext, newPacket);
-                        }
-
-                        @Override
-                        public void write(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise promise) throws Exception {
-                            this.handleConnectionChannel(packet);
-
-                            Object newPacket = Compatibility.COMPATIBLE_PACKET_LISTENER.writePacket(channelHandlerContext, packet, promise, false);
-                            super.write(channelHandlerContext, newPacket, promise);
-                        }
-
-                        public void handleConnectionChannel(Object packet) {
-                            if (packet instanceof ClientboundGameProfilePacket clientboundGameProfilePacket) {
-                                NoEncryption.serverChannels.put(clientboundGameProfilePacket.getGameProfile().getId(), channel);
-                            }
-                        }
-                    };
-
-                    if (pipeline.get("packet_handler") == null) {
-                        pipeline.addLast("noencryption_serverlevel", handler);
-                    } else {
-                        pipeline.addBefore("packet_handler", "noencryption_serverlevel", handler);
-                    }
-                }
-            });
-        }, 1, 1);
-
-        NoEncryption.testerTask = Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), () -> {
-            NoEncryption.serverChannels.forEach((uuid, channel) -> {
-                if (Bukkit.getPlayer(uuid) == null) {
-                    channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_serverlevel"));
-                    NoEncryption.serverChannels.remove(uuid);
-                }
-            });
-        }, 20, 20);
-    }
-
-    public static void stopConnectionListenTimer() {
-        if (NoEncryption.timerTask != null)
-            NoEncryption.timerTask.cancel();
-
-        if (NoEncryption.testerTask != null)
-            NoEncryption.testerTask.cancel();
-    }
-
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerJoin (PlayerJoinEvent e) {
         final Player player = e.getPlayer();
-        final ChannelPipeline pipeline;
+        final Channel channel;
         try {
-            pipeline = Compatibility.COMPATIBLE_PLAYER.getChannel(player).pipeline();
+            channel = Compatibility.COMPATIBLE_PLAYER.getChannel(player);
         } catch (NoSuchFieldException | IllegalAccessException ex) {
             NoEncryption.logger().severe("An error occurred while retrieving the player's channel for injection!");
             throw new RuntimeException(ex);
         }
+        final ChannelPipeline pipeline = channel.pipeline();
         final ChannelDuplexHandler handler = new ChannelDuplexHandler() {
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -94,9 +37,9 @@ public class PlayerListener implements Listener {
         };
 
         if (pipeline.get("packet_handler") == null) {
-            pipeline.addLast("noencryption_playerlevel", handler);
+            pipeline.addLast(NoEncryption.playerHandlerName, handler);
         } else {
-            pipeline.addBefore("packet_handler", "noencryption_playerlevel", handler);
+            pipeline.addBefore("packet_handler", NoEncryption.playerHandlerName, handler);
         }
 
         if (ConfigurationHandler.Config.getLoginProtectionMessage() != null) {
@@ -104,6 +47,8 @@ public class PlayerListener implements Listener {
                 Chat.sendChat(player, ConfigurationHandler.Config.getLoginProtectionMessage());
             }
         }
+
+        NoEncryption.addPlayerChannel(channel);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -120,7 +65,7 @@ public class PlayerListener implements Listener {
         }
 
         try {
-            channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+            channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
 
             serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove("noencryption_serverlevel"));
             NoEncryption.serverChannels.remove(player.getUniqueId());

--- a/1.19.4/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
@@ -1,0 +1,30 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class PlayerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), PlayerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.activePlayerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.playerHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.playerHandlerName);
+
+                    NoEncryption.removePlayerChannel(channel);
+                } else {
+                    NoEncryption.removePlayerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/1.19.4/src/main/java/me/doclic/noencryption/utils/ServerChannelGC.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/utils/ServerChannelGC.java
@@ -1,0 +1,37 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class ServerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), ServerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.serverChannels.forEach((uuid, channel) -> {
+            if (Bukkit.getPlayer(uuid) == null) {
+                channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.serverHandlerName));
+                NoEncryption.serverChannels.remove(uuid);
+            }
+        });
+
+        NoEncryption.activeServerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.serverHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.serverHandlerName);
+
+                    NoEncryption.removeServerChannel(channel);
+                } else {
+                    NoEncryption.removeServerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/1.19/src/main/java/me/doclic/noencryption/NoEncryption.java
+++ b/1.19/src/main/java/me/doclic/noencryption/NoEncryption.java
@@ -1,24 +1,36 @@
 package me.doclic.noencryption;
 
+import io.netty.channel.Channel;
 import me.doclic.noencryption.commands.MainCommand;
 import me.doclic.noencryption.compatibility.Compatibility;
 import me.doclic.noencryption.config.ConfigurationHandler;
+import me.doclic.noencryption.utils.PlayerChannelGC;
 import me.doclic.noencryption.utils.FileMgmt;
 import me.doclic.noencryption.utils.InternalMetrics;
 import me.doclic.noencryption.utils.updates.UpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Logger;
 
 public final class NoEncryption extends JavaPlugin {
     private static NoEncryption plugin;
     private static Logger logger;
+    public static List<Channel> activePlayerChannels;
+
+    private static BukkitTask playerGarbageCollectorTask;
+
+    public static final String playerHandlerName = "noencryption_playerlevel";
 
     @Override
     public void onEnable() {
         plugin = this;
         logger = getLogger();
+        activePlayerChannels = Collections.unmodifiableList(new ArrayList<>());
 
         if (Compatibility.SERVER_COMPATIBLE) {
             FileMgmt.initialize(this);
@@ -35,6 +47,8 @@ public final class NoEncryption extends JavaPlugin {
 
             getCommand("noencryption").setExecutor(new MainCommand());
             getCommand("noencryption").setTabCompleter(new MainCommand());
+
+            startTasks();
 
             Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
 
@@ -86,6 +100,19 @@ public final class NoEncryption extends JavaPlugin {
 
     }
 
+    @Override
+    public void onDisable() {
+        stopTasks();
+    }
+
+    private static void startTasks() {
+        playerGarbageCollectorTask = PlayerChannelGC.start();
+    }
+
+    private static void stopTasks() {
+        PlayerChannelGC.stop(playerGarbageCollectorTask);
+    }
+
     public static NoEncryption plugin() {
         return plugin;
     }
@@ -106,5 +133,17 @@ public final class NoEncryption extends JavaPlugin {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    public static void addPlayerChannel(Channel channel) {
+        List<Channel> modified = new ArrayList<>(activePlayerChannels);
+        modified.add(channel);
+        activePlayerChannels = Collections.unmodifiableList(modified);
+    }
+
+    public static void removePlayerChannel(Channel channel) {
+        List<Channel> modified = new ArrayList<>(activePlayerChannels);
+        modified.remove(channel);
+        activePlayerChannels = Collections.unmodifiableList(modified);
     }
 }

--- a/1.19/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -46,6 +46,12 @@ public class PlayerListener implements Listener {
     public void onPlayerQuit (PlayerQuitEvent e) {
         final Player player = e.getPlayer();
         final Channel channel = Compatibility.COMPATIBLE_PLAYER.getChannel(player);
-        channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+
+        try {
+            channel.eventLoop().submit(() -> channel.pipeline().remove("noencryption_playerlevel"));
+        } catch (NullPointerException ex) {
+            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            ex.printStackTrace();
+        }
     }
 }

--- a/1.19/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
+++ b/1.19/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
@@ -1,0 +1,30 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class PlayerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), PlayerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.activePlayerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.playerHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.playerHandlerName);
+
+                    NoEncryption.removePlayerChannel(channel);
+                } else {
+                    NoEncryption.removePlayerChannel(channel);;
+                }
+            }
+        });
+    }
+}

--- a/Reflection/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
@@ -19,5 +20,11 @@ public class PlayerListener implements Listener {
                 Chat.sendChat(player, ConfigurationHandler.Config.getLoginProtectionMessage());
             }
         }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerQuit (PlayerQuitEvent e) {
+        final Player player = e.getPlayer();
+        Compatibility.VERSION_HANDLER.stop(player);
     }
 }

--- a/Reflection/src/main/java/me/doclic/noencryption/compatibility/versionhandler/VersionHandler.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/compatibility/versionhandler/VersionHandler.java
@@ -1,5 +1,6 @@
 package me.doclic.noencryption.compatibility.versionhandler;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -78,6 +79,29 @@ public interface VersionHandler {
         }
     }
 
+    default void stop(Player player) {
+        try {
+            final Channel channel = NMSInterface.getNettyChannel(player);
+
+            channel.eventLoop().submit(() -> channel.pipeline().remove(PACKET_HANDLER_NAME));
+        } catch (InvocationTargetException | IllegalAccessException | NullPointerException e) {
+            NoEncryption.logger().warning("Couldn't remove NE packet handler for player " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("Did you use \"/reload\"?");
+            NoEncryption.logger().warning("To fix this, try updating NoEncryption by downloading a JAR from");
+            NoEncryption.logger().warning("https://github.com/Doclic/NoEncryption/releases");
+            NoEncryption.logger().warning("You can download the multi-version JAR which is slower but supports multiple versions");
+            NoEncryption.logger().warning("or you can also download a JAR for your specific version which may fix the issue");
+            NoEncryption.logger().warning("If the issue persists this might mean that your server is running on an unsupported");
+            NoEncryption.logger().warning("Minecraft version, in which case you'll have to wait for the developers to update NE");
+            NoEncryption.logger().warning("This NoEncryption build supports versions 1.19-1.19.3");
+            NoEncryption.logger().warning("Otherwise, please create an issue on the NoEncryption GitHub at");
+            NoEncryption.logger().warning("https://github.com/Doclic/NoEncryption/issues");
+            NoEncryption.logger().warning("And provide the following:");
+            NoEncryption.logger().warning("Minecraft version, server implementation (such as Spigot, Paper, etc), NE version,");
+            NoEncryption.logger().warning("and the stacktrace shown below");
+            e.printStackTrace();
+        }
+    }
 
     default Object readPacket(Object packet) throws Exception { return packet; }
     Object writePacket(Object packet) throws Exception;

--- a/Reflection/src/main/java/me/doclic/noencryption/compatibility/versionhandler/VersionHandler.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/compatibility/versionhandler/VersionHandler.java
@@ -18,7 +18,8 @@ public interface VersionHandler {
 
     default void listen(Player player) {
         try {
-            NMSInterface.getNettyChannel(player).pipeline().addBefore("packet_handler", PACKET_HANDLER_NAME, new ChannelDuplexHandler() {
+            final Channel channel = NMSInterface.getNettyChannel(player);
+            channel.pipeline().addBefore("packet_handler", PACKET_HANDLER_NAME, new ChannelDuplexHandler() {
                 @Override
                 public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                     try {
@@ -53,6 +54,8 @@ public interface VersionHandler {
                     if(msg != null) super.write(ctx, msg, promise);
                 }
             });
+
+            NoEncryption.addPlayerChannel(channel);
         } catch (InvocationTargetException | IllegalAccessException e) {
             NoEncryption.logger().severe("Couldn't add NE packet handler for player " + player.getName() + " (" + player.getUniqueId() + ")");
             NoEncryption.logger().severe("The player has been kicked to prevent them from being able to report others");

--- a/Reflection/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/utils/PlayerChannelGC.java
@@ -1,0 +1,30 @@
+package me.doclic.noencryption.utils;
+
+import me.doclic.noencryption.NoEncryption;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+public class PlayerChannelGC {
+    public static BukkitTask start() {
+        return Bukkit.getScheduler().runTaskTimerAsynchronously(NoEncryption.plugin(), PlayerChannelGC::runGC, 100, 100);
+    }
+
+    public static void stop(BukkitTask task) {
+        if (task != null)
+            task.cancel();
+    }
+
+    private static void runGC() {
+        NoEncryption.activePlayerChannels.forEach(channel -> {
+            if (!channel.isOpen()) {
+                if (channel.pipeline().get(NoEncryption.playerHandlerName) != null) {
+                    channel.pipeline().remove(NoEncryption.playerHandlerName);
+
+                    NoEncryption.removePlayerChannel(channel);
+                } else {
+                    NoEncryption.removePlayerChannel(channel);;
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
<details>
<summary>By creating a pull request, you agree to the following</summary>

<ul>
<li>The code included in this PR is in no way malicious, or used for my personal gain.</li>
<li>The code included in this PR is intended to benefit, add a universal feature, fix a bug(s), or make a function more efficient.</li>
<li>The code included in this PR is <b>not</b> intended for one time use/personal use. (ex. compatibility with your personal plugin)</li>
<li>The code included in this PR follows the licensing of it's origination.</li>
<li>The code included in this PR is tested, and follows all laws, regulations, rules, and other listed restrictions.</li>
</ul>

</details>

## Type of Change

What type of fix(es) are included in this pull request?

- [X] Bug Fix
- [ ] New Feature
- [ ] Other (Describe below)

<details>
  <summary><h3>Other (Only applies if Other is selected above)</h3></summary>
  <br>
  
  - 
  
</details>

## Link(s) to related issue(s) and their issue number(s)

List of links to issues that this PR relates to or closes

- #71 

## Changes

Describe all the changes that were made

- Added multiple `try`/`catch` checks for NPEs when removing the NoEncryption handler from the channel pipelines

## Testing Required

Do the applied changes require testing? (Depends on if core components were changed)

- [X] Yes, these changes require testing
- [ ] No, these changes do not require testing

<details>
  <summary><b>Testing Environment (If the above is Yes)</b></summary>
  <br>
  
  <b>1.19 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19 Build 1735
  - [ ] ~~Tested player joining~~
  - [ ] ~~Tested chats **Player -> Server**~~
  - [ ] ~~Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)~~
  - [ ] ~~Tested chats **Server -> Player** (Using /say, /me, etc.)~~
  - [ ] ~~Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)~~
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.1 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19.1 Build 1751
  - [ ] ~~Tested player joining~~
  - [ ] ~~Tested chats **Player -> Server**~~
  - [ ] ~~Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)~~
  - [ ] ~~Tested chats **Server -> Player** (Using /say, /me, etc.)~~
  - [ ] ~~Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)~~
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.2 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19.2 Build 1858
  - [ ] ~~Tested player joining~~
  - [ ] ~~Tested chats **Player -> Server**~~
  - [ ] ~~Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)~~
  - [ ] ~~Tested chats **Server -> Player** (Using /say, /me, etc.)~~
  - [ ] ~~Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)~~
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.3 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Purpur 1.19.3 Build 1920
  - [ ] ~~Tested player joining~~
  - [ ] ~~Tested chats **Player -> Server**~~
  - [ ] ~~Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)~~
  - [ ] ~~Tested chats **Server -> Player** (Using /say, /me, etc.)~~
  - [ ] ~~Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)~~
  - [X] Tested Reflection with above
  
  <br>
  
  <b>1.19.4 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): Paper 1.19.4 Build 60
  - [ ] ~~Tested player joining~~
  - [ ] ~~Tested chats **Player -> Server**~~
  - [ ] ~~Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)~~
  - [ ] ~~Tested chats **Server -> Player** (Using /say, /me, etc.)~~
  - [ ] ~~Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)~~
  - [X] Tested Reflection with above
  
</details>

## Self Review

- [X] I have performed a self-review of my code
- [X] My code successfully compiles through Maven every time, without any compiler warnings
- [X] My code has been checked for leftover development code/comments such as debug outputs
