### PR TITLE
Added a notice about garbage collection on error

### DIFF
--- a/1.19.1/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.1/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -53,8 +53,8 @@ public class PlayerListener implements Listener {
         try {
             channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
         } catch (NullPointerException ex) {
-            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
-            ex.printStackTrace();
+            NoEncryption.logger().warning("Could not remove the player packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
         }
     }
 }

--- a/1.19.2/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.2/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -53,8 +53,8 @@ public class PlayerListener implements Listener {
         try {
             channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
         } catch (NullPointerException ex) {
-            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
-            ex.printStackTrace();
+            NoEncryption.logger().warning("Could not remove the player packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
         }
     }
 }

--- a/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.3/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -52,13 +52,18 @@ public class PlayerListener implements Listener {
         final Channel serverChannel = NoEncryption.serverChannels.get(player.getUniqueId());
 
         try {
-            channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
-
-            serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove("noencryption_serverlevel"));
+            serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove(NoEncryption.serverHandlerName));
             NoEncryption.serverChannels.remove(player.getUniqueId());
         } catch (NullPointerException ex) {
-            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
-            ex.printStackTrace();
+            NoEncryption.logger().warning("Could not remove the server packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
+        }
+
+        try{
+            channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
+        } catch (NullPointerException ex) {
+            NoEncryption.logger().warning("Could not remove the player packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
         }
     }
 }

--- a/1.19.4/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19.4/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -65,13 +65,18 @@ public class PlayerListener implements Listener {
         }
 
         try {
-            channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
-
-            serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove("noencryption_serverlevel"));
+            serverChannel.eventLoop().submit(() -> serverChannel.pipeline().remove(NoEncryption.serverHandlerName));
             NoEncryption.serverChannels.remove(player.getUniqueId());
         } catch (NullPointerException ex) {
-            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
-            ex.printStackTrace();
+            NoEncryption.logger().warning("Could not remove the server packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
+        }
+
+        try{
+            channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
+        } catch (NullPointerException ex) {
+            NoEncryption.logger().warning("Could not remove the player packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
         }
     }
 }

--- a/1.19/src/main/java/me/doclic/noencryption/PlayerListener.java
+++ b/1.19/src/main/java/me/doclic/noencryption/PlayerListener.java
@@ -53,8 +53,8 @@ public class PlayerListener implements Listener {
         try {
             channel.eventLoop().submit(() -> channel.pipeline().remove(NoEncryption.playerHandlerName));
         } catch (NullPointerException ex) {
-            NoEncryption.logger().warning("Could not remove the packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
-            ex.printStackTrace();
+            NoEncryption.logger().warning("Could not remove the player packet handler for " + player.getName() + " (" + player.getUniqueId() + ")");
+            NoEncryption.logger().warning("This is not a fatal error, will be cleaned in garbage collection, and can be safely ignored");
         }
     }
 }

--- a/Reflection/src/main/java/me/doclic/noencryption/compatibility/versionhandler/VersionHandler.java
+++ b/Reflection/src/main/java/me/doclic/noencryption/compatibility/versionhandler/VersionHandler.java
@@ -89,7 +89,7 @@ public interface VersionHandler {
             channel.eventLoop().submit(() -> channel.pipeline().remove(PACKET_HANDLER_NAME));
         } catch (InvocationTargetException | IllegalAccessException | NullPointerException e) {
             NoEncryption.logger().warning("Couldn't remove NE packet handler for player " + player.getName() + " (" + player.getUniqueId() + ")");
-            NoEncryption.logger().warning("Did you use \"/reload\"?");
+            NoEncryption.logger().warning("It is possible this will be cleaned in garbage collection. Did you use \"/reload\"?");
             NoEncryption.logger().warning("To fix this, try updating NoEncryption by downloading a JAR from");
             NoEncryption.logger().warning("https://github.com/Doclic/NoEncryption/releases");
             NoEncryption.logger().warning("You can download the multi-version JAR which is slower but supports multiple versions");


### PR DESCRIPTION
<details>
<summary>By creating a pull request, you agree to the following</summary>

<ul>
<li>The code included in this PR is in no way malicious, or used for my personal gain.</li>
<li>The code included in this PR is intended to benefit, add a universal feature, fix a bug(s), or make a function more efficient.</li>
<li>The code included in this PR is <b>not</b> intended for one time use/personal use. (ex. compatibility with your personal plugin)</li>
<li>The code included in this PR follows the licensing of it's origination.</li>
<li>The code included in this PR is tested, and follows all laws, regulations, rules, and other listed restrictions.</li>
</ul>

</details>

## Type of Change

What type of fix(es) are included in this pull request?

- [X] Bug Fix
- [ ] New Feature
- [ ] Other (Describe below)

<details>
  <summary><h3>Other (Only applies if Other is selected above)</h3></summary>
  <br>
  
  - 
  
</details>

## Link(s) to related issue(s) and their issue number(s)

List of links to issues that this PR relates to or closes

- #89 
- #71 

## Changes

Describe all the changes that were made

- Rewrote exception messages for NPEs on player quit events

## Testing Required

Do the applied changes require testing? (Depends on if core components were changed)

- [ ] Yes, these changes require testing
- [X] No, these changes do not require testing

<details>
  <summary><b>Testing Environment (If the above is Yes)</b></summary>
  <br>
  
  <b>1.19 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): 
  - [ ] Tested player joining
  - [ ] Tested chats **Player -> Server**
  - [ ] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [ ] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [ ] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [ ] Tested Reflection with above
  
  <br>
  
  <b>1.19.1 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): 
  - [ ] Tested player joining
  - [ ] Tested chats **Player -> Server**
  - [ ] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [ ] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [ ] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [ ] Tested Reflection with above
  
  <br>
  
  <b>1.19.2 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): 
  - [ ] Tested player joining
  - [ ] Tested chats **Player -> Server**
  - [ ] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [ ] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [ ] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [ ] Tested Reflection with above
  
  <br>
  
  <b>1.19.3 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): 
  - [ ] Tested player joining
  - [ ] Tested chats **Player -> Server**
  - [ ] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [ ] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [ ] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [ ] Tested Reflection with above
  
  <br>
  
  <b>1.19.4 Tests</b>
  - <b>Server Distribution</b> (CraftBukkit, Spigot, Purpur, and it's build number): 
  - [ ] Tested player joining
  - [ ] Tested chats **Player -> Server**
  - [ ] Tested command chats **Player -> Server** (Using /tell, /me, /say, etc.)
  - [ ] Tested chats **Server -> Player** (Using /say, /me, etc.)
  - [ ] Tested chat formatting (Using third party plugins such as TownyChat, EssentialsXChat, etc.)
  - [ ] Tested Reflection with above
  
</details>

## Self Review

- [X] I have performed a self-review of my code
- [X] My code successfully compiles through Maven every time, without any compiler warnings
- [X] My code has been checked for leftover development code/comments such as debug outputs
